### PR TITLE
Fix code scanning alert no. 1: Exposure of private files

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+thearcanledger.app

--- a/app.js
+++ b/app.js
@@ -19,8 +19,8 @@ const PORT = process.env.PORT || 3000;
 // Middleware to parse JSON
 app.use(express.json());
 
-// Serve static files from the current directory
-app.use(express.static(__dirname));
+// Serve static files from the 'public' directory
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Array of CA-related responses for randomization
 const caResponses = [


### PR DESCRIPTION
Fixes [https://github.com/TheArcanLedger/TheArcanLedger/security/code-scanning/1](https://github.com/TheArcanLedger/TheArcanLedger/security/code-scanning/1)

To fix the problem, we need to limit the directories being served to only those that contain static files intended for public access. This can be achieved by specifying the exact subdirectories within the source root folder that should be served. For example, if the static files are located in a `public` directory within the source root folder, we should serve only that directory.

1. Identify the subdirectory within the source root folder that contains the static files intended for public access.
2. Update the `app.use` statement to serve only the identified subdirectory instead of the entire source root folder.
3. Ensure that no sensitive files are included in the served subdirectory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
